### PR TITLE
Enable tree-sitter queries for Arizona and Erlang syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,46 @@ require('lspconfig').elp.setup({
 })
 ```
 
+## Development
+
+To test the local plugin during development:
+
+```lua
+{
+  dir = "/path/to/arizona.nvim",
+  name = "arizona.nvim",
+  dependencies = {
+    "nvim-treesitter/nvim-treesitter",
+    "jmbuhr/otter.nvim",
+  },
+}
+```
+
+### Development Commands
+
+```bash
+# Install dependencies for local development
+make install
+
+# Run tests
+make test
+
+# Check code formatting
+make lint
+
+# Format code with stylua
+make format
+
+# Run health check
+make health
+
+# Clean temporary files
+make clean
+
+# Run all CI checks (lint + test + health)
+make ci
+```
+
 ## Troubleshooting
 
 Run `:checkhealth arizona` to see what's working and what needs setup.

--- a/plugin/arizona.lua
+++ b/plugin/arizona.lua
@@ -27,6 +27,7 @@ local function setup_treesitter()
       branch = "main",
     },
     filetype = "arizona",
+    used_by = { "arizona", "erlang" },
   }
 end
 

--- a/tests/arizona_spec.lua
+++ b/tests/arizona_spec.lua
@@ -61,6 +61,7 @@ describe("Arizona Framework Plugin", function()
         )
         assert.same({ "src/parser.c" }, parser_config.install_info.files)
         assert.equals("main", parser_config.install_info.branch)
+        assert.same({ "arizona", "erlang" }, parser_config.used_by)
       else
         pending("nvim-treesitter not available in test environment")
       end


### PR DESCRIPTION
- Add used_by configuration to enable both Arizona template and Erlang code highlighting
- Update tests to verify parser configuration includes used_by field
- Add development commands documentation to README